### PR TITLE
Autofix: Node to Composition Link with an sh:inversePath is not working

### DIFF
--- a/projects/blueprint/src/app/core/service/graph/aggregate/model/composition/composition-to-node-link.ts
+++ b/projects/blueprint/src/app/core/service/graph/aggregate/model/composition/composition-to-node-link.ts
@@ -103,7 +103,22 @@ export class CompositionToNodeLink extends ClownfaceObject implements ICompositi
      * 
      * @readonly
      */
-    get path(): PathDefinition[][] {
+     get path(): PathDefinition[][] {
+         const path = this._node.out(shacl.propertyNamedNode).map(p => {
+             const targetClass = p.out(shacl.targetClassNamedNode).values[0];
+             const shClass = p.out(shacl.classNamedNode).values[0];
+             const cfPath = p.out(shacl.pathNamedNode).toArray()[0];
+
+             if (cfPath.term.termType === 'NamedNode') {
+                 return [new PathDefinition(targetClass, shClass, `<${cfPath.value}>`)];
+             }
+             if (cfPath.term.termType === 'BlankNode') {
+                 const inversePath = cfPath.out(shacl.inversePathNamedNode).values[0];
+                 return [new PathDefinition(targetClass, shClass, `^<${inversePath}>`)];
+             }
+             console.warn(`no path found for path element: ${p}`);
+             return [] as PathDefinition[];
+         });
         const path = this._node.out(shacl.propertyNamedNode).map(p => {
             const targetClass = p.out(shacl.targetClassNamedNode).values[0];
             const shClass = p.out(shacl.classNamedNode).values[0];


### PR DESCRIPTION
Modified the CompositionToNodeLink class to correctly handle inverse paths when creating queries. This addresses the issue where Node to Composition Links were not working correctly with inverse paths from Connection points to Nodes. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    