### PR TITLE
chore: remove plain strings used for dialects

### DIFF
--- a/projects/blueprint/src/app/core/service/config/config.service.ts
+++ b/projects/blueprint/src/app/core/service/config/config.service.ts
@@ -5,6 +5,7 @@ import { LibraryConfigurationService } from '@blueprint/service/library-configur
 
 import { Observable, tap } from 'rxjs';
 import { environment } from '../../../../environments/environment';
+import {FullTextSearchDialectName} from "@blueprint/service/sparql/sparql.service";
 @Injectable({
   providedIn: 'root'
 })
@@ -37,7 +38,7 @@ export class ConfigService {
       this._libraryConfigurationService.sparqlConsoleUrl = environment.sparqlConsoleUrl;
       this._libraryConfigurationService.graphExplorerUrl = environment.graphExplorerUrl;
       this._libraryConfigurationService.production = environment.production;
-      this._libraryConfigurationService.fullTextSearchDialect = environment.fullTextSearchDialect as "fuseki" | "stardog";
+      this._libraryConfigurationService.fullTextSearchDialect = environment.fullTextSearchDialect;
 
     }))
   }
@@ -51,5 +52,5 @@ export type FluxConfig = {
   readonly endpointUrl: string,
   readonly sparqlConsoleUrl: string,
   readonly graphExplorerUrl: string,
-  readonly fullTextSearchDialect: 'fuseki' | 'stardog'
+  readonly fullTextSearchDialect: FullTextSearchDialectName
 }

--- a/projects/blueprint/src/app/core/service/config/config.service.ts
+++ b/projects/blueprint/src/app/core/service/config/config.service.ts
@@ -5,7 +5,7 @@ import { LibraryConfigurationService } from '@blueprint/service/library-configur
 
 import { Observable, tap } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import {FullTextSearchDialectName} from "@blueprint/service/sparql/sparql.service";
+import { FullTextSearchDialect } from "@blueprint/service/sparql/sparql.service";
 @Injectable({
   providedIn: 'root'
 })
@@ -52,5 +52,5 @@ export type FluxConfig = {
   readonly endpointUrl: string,
   readonly sparqlConsoleUrl: string,
   readonly graphExplorerUrl: string,
-  readonly fullTextSearchDialect: FullTextSearchDialectName
+  readonly fullTextSearchDialect: FullTextSearchDialect
 }

--- a/projects/blueprint/src/app/core/service/library-configuration/library-configuration.service.ts
+++ b/projects/blueprint/src/app/core/service/library-configuration/library-configuration.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { LibraryConfiguration } from './library-configuration.model';
-import {FullTextSearchDialect, FullTextSearchDialectName} from '../sparql/sparql.service';
+import { FullTextSearchDialect } from '../sparql/sparql.service';
 
 @Injectable({
   providedIn: 'root'
@@ -22,7 +22,7 @@ export class LibraryConfigurationService {
     return this.configuration.fullTextSearchDialect;
   }
 
-  set fullTextSearchDialect(value: FullTextSearchDialectName) {
+  set fullTextSearchDialect(value: FullTextSearchDialect) {
     switch (value) {
       case 'fuseki':
         this.configuration.fullTextSearchDialect = FullTextSearchDialect.FUSEKI;

--- a/projects/blueprint/src/app/core/service/library-configuration/library-configuration.service.ts
+++ b/projects/blueprint/src/app/core/service/library-configuration/library-configuration.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { LibraryConfiguration } from './library-configuration.model';
-import { FullTextSearchDialect } from '../sparql/sparql.service';
+import {FullTextSearchDialect, FullTextSearchDialectName} from '../sparql/sparql.service';
 
 @Injectable({
   providedIn: 'root'
@@ -22,7 +22,7 @@ export class LibraryConfigurationService {
     return this.configuration.fullTextSearchDialect;
   }
 
-  set fullTextSearchDialect(value: 'fuseki' | 'stardog' | 'neptune' | 'graphdb') {
+  set fullTextSearchDialect(value: FullTextSearchDialectName) {
     switch (value) {
       case 'fuseki':
         this.configuration.fullTextSearchDialect = FullTextSearchDialect.FUSEKI;

--- a/projects/blueprint/src/app/core/service/sparql/sparql.service.ts
+++ b/projects/blueprint/src/app/core/service/sparql/sparql.service.ts
@@ -97,5 +97,3 @@ export enum FullTextSearchDialect {
   NEPTUNE = 'neptune',
   GRAPHDB = 'graphdb'
 }
-
-export type FullTextSearchDialectName = FullTextSearchDialect[keyof FullTextSearchDialect];

--- a/projects/blueprint/src/app/core/service/sparql/sparql.service.ts
+++ b/projects/blueprint/src/app/core/service/sparql/sparql.service.ts
@@ -29,9 +29,9 @@ export class SparqlService {
 
   /**
    * Execute a SPARQL SELECT query
-   * 
+   *
    * @param query The SPARQL SELECT query
-   * @returns an observable of the resulting bindings 
+   * @returns an observable of the resulting bindings
    */
   select(query: string): Observable<Record<string, SparqlResultTerm>[]> {
     const endpoint = this.libraryConfigurationService.endpointUrl;
@@ -58,7 +58,7 @@ export class SparqlService {
 
   /**
    * Execute a SPARQL CONSTRUCT query
-   * 
+   *
    * @param query The SPARQL CONSTRUCT query
    * @returns an observable of the resulting dataset
    */
@@ -97,3 +97,5 @@ export enum FullTextSearchDialect {
   NEPTUNE = 'neptune',
   GRAPHDB = 'graphdb'
 }
+
+export type FullTextSearchDialectName = FullTextSearchDialect[keyof FullTextSearchDialect];

--- a/projects/blueprint/src/environments/environment.development.ts
+++ b/projects/blueprint/src/environments/environment.development.ts
@@ -2,14 +2,14 @@
 // `ng build --configuration production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-import { FullTextSearchDialectName } from "@blueprint/service/sparql/sparql.service";
+import { FullTextSearchDialect } from "@blueprint/service/sparql/sparql.service";
 
 export const environment = {
     production: false,
     endpointUrl: 'http://localhost:4200/query',  // this will be overwritten by /src/config.json
     sparqlConsoleUrl: null, // e.g. yasgui -> will be overwritten by /src/config.json
     graphExplorerUrl: null, // this will be overwritten by /src/config.json
-    fullTextSearchDialect: 'neptune' as FullTextSearchDialectName, // this will be overwritten by /src/config.json
+    fullTextSearchDialect: 'neptune' as FullTextSearchDialect, // this will be overwritten by /src/config.json
     neptune: {
         ftsEndpoint: "https://vpc-opensearch-zazuko-blueprint-glbaecqrcqwr5om3z5jj2duuiq.eu-central-1.es.amazonaws.com"
     } // this will be overwritten by /src/config.json// this will be overwritten by /src/config.json

--- a/projects/blueprint/src/environments/environment.development.ts
+++ b/projects/blueprint/src/environments/environment.development.ts
@@ -2,12 +2,14 @@
 // `ng build --configuration production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
+import { FullTextSearchDialectName } from "@blueprint/service/sparql/sparql.service";
+
 export const environment = {
     production: false,
     endpointUrl: 'http://localhost:4200/query',  // this will be overwritten by /src/config.json
     sparqlConsoleUrl: null, // e.g. yasgui -> will be overwritten by /src/config.json
     graphExplorerUrl: null, // this will be overwritten by /src/config.json
-    fullTextSearchDialect: 'neptune', // this will be overwritten by /src/config.json
+    fullTextSearchDialect: 'neptune' as FullTextSearchDialectName, // this will be overwritten by /src/config.json
     neptune: {
         ftsEndpoint: "https://vpc-opensearch-zazuko-blueprint-glbaecqrcqwr5om3z5jj2duuiq.eu-central-1.es.amazonaws.com"
     } // this will be overwritten by /src/config.json// this will be overwritten by /src/config.json

--- a/projects/blueprint/src/environments/environment.ts
+++ b/projects/blueprint/src/environments/environment.ts
@@ -1,11 +1,11 @@
-import type {FullTextSearchDialectName} from "@blueprint/service/sparql/sparql.service";
+import type { FullTextSearchDialect } from "@blueprint/service/sparql/sparql.service";
 
 export const environment = {
     production: true,
     endpointUrl: 'https://ld.flux.zazuko.com/query', // this will be overwritten by /src/config.json
     sparqlConsoleUrl: null, // e.g. yasgui -> will be overwritten by /src/config.json
     graphExplorerUrl: null, // this will be overwritten by /src/config.json
-    fullTextSearchDialect: 'neptune' as FullTextSearchDialectName, // this will be overwritten by /src/config.json
+    fullTextSearchDialect: 'neptune' as FullTextSearchDialect, // this will be overwritten by /src/config.json
     neptune: {
         ftsEndpoint: "https://vpc-opensearch-zazuko-blueprint-glbaecqrcqwr5om3z5jj2duuiq.eu-central-1.es.amazonaws.com"
     } // this will be overwritten by /src/config.json

--- a/projects/blueprint/src/environments/environment.ts
+++ b/projects/blueprint/src/environments/environment.ts
@@ -1,9 +1,11 @@
+import type {FullTextSearchDialectName} from "@blueprint/service/sparql/sparql.service";
+
 export const environment = {
     production: true,
     endpointUrl: 'https://ld.flux.zazuko.com/query', // this will be overwritten by /src/config.json
     sparqlConsoleUrl: null, // e.g. yasgui -> will be overwritten by /src/config.json
     graphExplorerUrl: null, // this will be overwritten by /src/config.json
-    fullTextSearchDialect: 'neptune', // this will be overwritten by /src/config.json
+    fullTextSearchDialect: 'neptune' as FullTextSearchDialectName, // this will be overwritten by /src/config.json
     neptune: {
         ftsEndpoint: "https://vpc-opensearch-zazuko-blueprint-glbaecqrcqwr5om3z5jj2duuiq.eu-central-1.es.amazonaws.com"
     } // this will be overwritten by /src/config.json


### PR DESCRIPTION
I noticed that the full-text search dialect enum is not used everywhere.
